### PR TITLE
retain z-index

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task('build:css', () => {
         .pipe(sass().on('error', sass.logError))
         .pipe(postcss([
             autoprefixer({ browsers: ['last 2 versions'] }),
-            cssnano()
+            cssnano({ zindex: false })
         ]))
         .pipe(gulp.dest('dist'))
 });


### PR DESCRIPTION
cssnano converts the z-index from 1060 to 3.  This preserves the z-index value.
